### PR TITLE
Add logging, stats and theme features

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -15,6 +15,18 @@
             padding: 0;
             color: #333;
         }
+        body.dark {
+            background-color: #121212;
+            color: #eee;
+        }
+        body.dark .container {
+            background-color: #1e1e1e;
+            border-color: #333;
+        }
+        body.dark .bot-item {
+            background-color: #1e1e1e;
+            border-color: #333;
+        }
         .header {
             text-align: center;
             padding: 40px 0;
@@ -139,6 +151,13 @@
         }
         .restart-button:hover {
             background-color: #fb8c00;
+        }
+        .stop-button {
+            background-color: #e53935;
+            border-color: #e53935;
+        }
+        .stop-button:hover {
+            background-color: #d32f2f;
         }
         .logout-button {
             padding: 12px 20px;
@@ -353,6 +372,7 @@
     <!-- Header con il Titolo -->
     <div class="header">
         <h1>nSanity &amp; Chapo Bot Service</h1>
+        <button id="themeToggle" style="margin-top:10px;">Tema</button>
     </div>
 
     <div class="container">
@@ -414,6 +434,7 @@
             <ul class="bot-list" id="botList">
                 <!-- Lista dei bot verrà popolata dinamicamente -->
             </ul>
+            <p><a href="/logs">Log</a> | <a href="/stats">Statistiche</a></p>
             <button class="logout-button" id="logoutButton">Logout</button>
         </div>
     </div>
@@ -610,6 +631,7 @@
                     botActions.classList.add('bot-actions');
 
                     const startButton = document.createElement('button');
+                    const stopButton = document.createElement('button');
 
                     // Trova lo stato del bot
                     const botStatusObj = statuses.find(s => s.botName === bot);
@@ -631,7 +653,12 @@
                         }
                     });
 
+                    stopButton.textContent = 'Stop Bot';
+                    stopButton.classList.add('stop-button');
+                    stopButton.addEventListener('click', () => stopBot(bot));
+
                     botActions.appendChild(startButton);
+                    botActions.appendChild(stopButton);
 
                     botHeader.appendChild(botName);
                     botHeader.appendChild(botActions);
@@ -730,7 +757,7 @@
 
                 // Aggiorna il pulsante in base allo stato
                 const botItem = statusDiv.closest('.bot-item');
-                const startButton = botItem.querySelector('.bot-actions button');
+                const startButton = botItem.querySelector('.bot-actions .start-button, .bot-actions .restart-button');
                 if (status.toLowerCase() === 'in esecuzione') {
                     startButton.textContent = 'Riavvia Bot';
                     startButton.classList.remove('start-button');
@@ -805,6 +832,31 @@
             });
         }
 
+        // Funzione per fermare il bot
+        function stopBot(bot) {
+            if (!confirm(`Fermare il bot ${bot}?`)) return;
+            fetch('/api/stop-bot', {
+                method: 'POST',
+                credentials: 'include',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({ name: bot, category: currentCategory }),
+            })
+            .then(response => response.json())
+            .then(data => {
+                if (data.message) {
+                    alert(data.message);
+                } else if (data.error) {
+                    alert(`Errore: ${data.error}`);
+                }
+            })
+            .catch(error => {
+                console.error(`Errore nello stop del bot ${bot}:`, error);
+                alert('Errore nello stop del bot');
+            });
+        }
+
         // Funzione per inviare comandi al bot
         function sendCommand(bot) {
             const commandField = document.getElementById(`command-${bot}-${currentCategory}`);
@@ -843,6 +895,16 @@
                     showLoginContainer();
                 });
         };
+
+        // Gestione tema
+        const themeToggle = document.getElementById('themeToggle');
+        themeToggle.addEventListener('click', () => {
+            document.body.classList.toggle('dark');
+            localStorage.setItem('theme', document.body.classList.contains('dark') ? 'dark' : 'light');
+        });
+        if (localStorage.getItem('theme') === 'dark') {
+            document.body.classList.add('dark');
+        }
     </script>
 </body>
 </html>

--- a/public/logs.html
+++ b/public/logs.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="it">
+<head>
+    <meta charset="UTF-8">
+    <title>Log</title>
+    <style>
+        body { font-family: Arial, sans-serif; padding: 20px; background-color: #f5f5f5; }
+        pre { background: #222; color: #eee; padding: 20px; overflow-x: auto; }
+    </style>
+</head>
+<body>
+    <h1>Log del Server</h1>
+    <pre id="logContent">Caricamento...</pre>
+    <script>
+        fetch('/api/logs', { credentials: 'include' })
+            .then(r => r.text())
+            .then(text => { document.getElementById('logContent').textContent = text; })
+            .catch(() => { document.getElementById('logContent').textContent = 'Errore nel caricamento dei log'; });
+    </script>
+</body>
+</html>

--- a/public/stats.html
+++ b/public/stats.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="it">
+<head>
+    <meta charset="UTF-8">
+    <title>Statistiche</title>
+    <style>
+        body { font-family: Arial, sans-serif; padding: 20px; background-color: #f5f5f5; }
+    </style>
+</head>
+<body>
+    <h1>Statistiche Bot</h1>
+    <div id="stats">Caricamento...</div>
+    <script>
+        fetch('/api/stats', { credentials: 'include' })
+            .then(r => r.json())
+            .then(data => {
+                document.getElementById('stats').textContent = `Bot totali: ${data.totalBots} - In esecuzione: ${data.runningBots}`;
+            })
+            .catch(() => { document.getElementById('stats').textContent = 'Errore nel caricamento delle statistiche'; });
+    </script>
+</body>
+</html>

--- a/server.js
+++ b/server.js
@@ -18,6 +18,21 @@ const cors = require('cors'); // Aggiunto per gestire CORS
 const app = express();
 const port = 3000; // Usa la porta che preferisci
 
+// Funzione per registrare i log su file
+function logEvent(message) {
+    const logDir = path.join(__dirname, 'logs');
+    if (!fs.existsSync(logDir)) {
+        fs.mkdirSync(logDir);
+    }
+    const logPath = path.join(logDir, 'server.log');
+    const entry = `[${new Date().toISOString()}] ${message}\n`;
+    fs.appendFile(logPath, entry, (err) => {
+        if (err) {
+            console.error('Errore nella scrittura del log:', err);
+        }
+    });
+}
+
 // Creazione del server HTTP e dell'istanza di Socket.io
 const server = http.createServer(app);
 const io = socketIo(server);
@@ -339,10 +354,13 @@ app.post('/api/start-bot', isAuthenticated, (req, res) => {
         delete botProcesses[botKey];
         // Invia lo stato aggiornato del bot
         io.emit('status', { botName, status: 'Stop', category });
+        logEvent(`Bot ${botName} terminato con codice ${code}`);
     });
 
     // Invia lo stato aggiornato del bot
     io.emit('status', { botName, status: 'In esecuzione', category });
+
+    logEvent(`Bot ${botName} avviato`);
 
     res.json({ message: `Bot ${botName} avviato!`, pid: botProcess.pid });
 });
@@ -402,12 +420,77 @@ app.post('/api/restart-bot', isAuthenticated, (req, res) => {
         delete botProcesses[botKey];
         // Invia lo stato aggiornato del bot
         io.emit('status', { botName, status: 'Stop', category });
+        logEvent(`Bot ${botName} terminato con codice ${code}`);
     });
 
     // Invia lo stato aggiornato del bot
     io.emit('status', { botName, status: 'In esecuzione', category });
 
+    logEvent(`Bot ${botName} riavviato`);
+
     res.json({ message: `Bot ${botName} riavviato!`, pid: botProcess.pid });
+});
+
+// API per fermare un bot - Protetta
+app.post('/api/stop-bot', isAuthenticated, (req, res) => {
+    const { name, category } = req.body;
+    const botKey = `${category || 'nSanity'}:${name}`;
+
+    if (!botProcesses[botKey]) {
+        return res.status(400).json({ error: 'Il bot non è in esecuzione' });
+    }
+
+    try {
+        process.kill(botProcesses[botKey].process.pid, 'SIGTERM');
+        delete botProcesses[botKey];
+        io.emit('status', { botName: name, status: 'Stop', category });
+        logEvent(`Bot ${name} fermato`);
+        res.json({ message: `Bot ${name} fermato` });
+    } catch (error) {
+        console.error(`Errore nello stop del bot ${name}:`, error);
+        res.status(500).json({ error: 'Errore nello stop del bot' });
+    }
+});
+
+// API per recuperare i log
+app.get('/api/logs', isAuthenticated, (req, res) => {
+    const logPath = path.join(__dirname, 'logs', 'server.log');
+    fs.readFile(logPath, 'utf8', (err, data) => {
+        if (err) {
+            return res.status(500).json({ error: 'Errore nella lettura dei log' });
+        }
+        res.type('text/plain').send(data);
+    });
+});
+
+// API per statistiche base
+app.get('/api/stats', isAuthenticated, (req, res) => {
+    const categories = Object.keys(botDirectories);
+    let totalBots = 0;
+    let runningBots = 0;
+
+    categories.forEach((cat) => {
+        const botsDirectory = botDirectories[cat];
+        const files = fs.readdirSync(botsDirectory, { withFileTypes: true });
+        const botFolders = files.filter(f => f.isDirectory()).map(f => f.name);
+        totalBots += botFolders.length;
+        botFolders.forEach(b => {
+            const key = `${cat}:${b}`;
+            if (botProcesses[key]) runningBots += 1;
+        });
+    });
+
+    res.json({ totalBots, runningBots });
+});
+
+// Pagina log
+app.get('/logs', (req, res) => {
+    res.sendFile(path.join(__dirname, 'public', 'logs.html'));
+});
+
+// Pagina statistiche
+app.get('/stats', (req, res) => {
+    res.sendFile(path.join(__dirname, 'public', 'stats.html'));
 });
 
 // Serviamo la pagina HTML principale


### PR DESCRIPTION
## Summary
- add server log utility and stop-bot endpoint
- expose log and statistics endpoints
- create new log and stats pages
- improve UI with dark mode toggle and stop button

## Testing
- `node -c server.js`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_686799b430ac83249a5836370f18b1cb